### PR TITLE
feat: add bypass for 1shortlink, tech8s, game5s, ez4short; improve ouo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 build/
+tsconfig.tsbuildinfo

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -12,8 +12,10 @@ import { initExeioAdblockInject } from '../sites/exeio';
 import { initCutyAdblockInject } from '../sites/cuty';
 import { initRinkuPageHooksInject } from '../sites/rinku';
 import { initStorylineScormMainWorldInject } from '../sites/storyline-scorm';
+import { initTech8sBackground } from '../sites/tech8s/background';
 
 initCoomeetMainWorldInject();
+initTech8sBackground();
 initDocumentVisibilitySpoof();
 initFclcAlertSuppress();
 initFclcLinksGo();

--- a/src/content-scripts/index.ts
+++ b/src/content-scripts/index.ts
@@ -73,8 +73,12 @@ import { initRinkuGate } from '../sites/rinku';
 import { initBstshrtGate } from '../sites/bstshrt';
 import { initLinkunlockerGate } from '../sites/linkunlocker';
 import { initStorylineCoursePlayBrand } from '../sites/storyline-scorm';
+import { init1shortlink } from '../sites/1shortlink';
+import { initTech8sSafeRedirect } from '../sites/tech8s';
 
 const INITS = [
+  init1shortlink,
+  initTech8sSafeRedirect,
   initStorylineCoursePlayBrand,
   initLinknextGate,
   initLinkvertiseAccessPage,

--- a/src/sites/1shortlink/hosts.ts
+++ b/src/sites/1shortlink/hosts.ts
@@ -1,0 +1,1 @@
+export const SHORTLINK_HOSTS = ['1shortlink.com'] as const;

--- a/src/sites/1shortlink/index.ts
+++ b/src/sites/1shortlink/index.ts
@@ -1,0 +1,108 @@
+import { createFullPageOverlay, type FullPageOverlay } from '../../injected-ui/full-page-overlay';
+import { buildFullPageOverlayCss, overlayActiveClass } from '../../injected-ui/overlay-styles';
+import { isAllowedHost } from '../../utils/domain-check';
+import { SHORTLINK_HOSTS } from './hosts';
+
+const OVERLAY_ID = 'skip-wait-1shortlink-overlay';
+const BOOT_STYLE_ID = 'skip-wait-1shortlink-boot';
+
+const NOTE = {
+  lead: 'Hang tight — unlocking your link.',
+  detail: "You don't need to tap anything on the page.",
+} as const;
+
+const ENCRYPTED_PATH_RE = /^\/link-encrypted\//;
+
+let ui: FullPageOverlay | null = null;
+let done = false;
+let cleanup: (() => void) | null = null;
+
+const bootOverlayLock = (): void => {
+  const active = overlayActiveClass(OVERLAY_ID);
+  document.documentElement.classList.add(active);
+  if (document.getElementById(BOOT_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = BOOT_STYLE_ID;
+  style.textContent = buildFullPageOverlayCss(OVERLAY_ID, active);
+  (document.head || document.documentElement).appendChild(style);
+};
+
+const mountUi = (status = 'Getting things ready…'): FullPageOverlay => {
+  bootOverlayLock();
+  if (ui) {
+    ui.setStatus(status);
+    ui.setError(null);
+    return ui;
+  }
+  ui = createFullPageOverlay({
+    id: OVERLAY_ID,
+    brand: 'Skip Wait',
+    note: NOTE,
+    status,
+    countdownLabel: 'Your link opens in',
+  });
+  return ui;
+};
+
+function destinationUrl(): string | null {
+  const btn = document.getElementById('redirect-link');
+  if (!btn) return null;
+  const href = btn.getAttribute('data-href')?.trim();
+  return href && (href.startsWith('http://') || href.startsWith('https://')) ? href : null;
+}
+
+function finish(url: string): void {
+  if (done) return;
+  done = true;
+  cleanup?.();
+  const overlay = mountUi('Opening your link…');
+  overlay.setNote({ lead: 'Your link is ready.', detail: 'Redirecting now…' });
+  location.replace(url);
+}
+
+export function init1shortlink(): void {
+  if (!isAllowedHost(SHORTLINK_HOSTS)) return;
+  if (!ENCRYPTED_PATH_RE.test(location.pathname)) return;
+
+  // Check immediately
+  const url = destinationUrl();
+  if (url) {
+    mountUi('Your link is ready…');
+    finish(url);
+    return;
+  }
+
+  // Show overlay
+  mountUi('Getting your link…');
+
+  // Single MutationObserver watching only data-href changes
+  const mo = new MutationObserver(() => {
+    const u = destinationUrl();
+    if (u) {
+      mo.disconnect();
+      finish(u);
+    }
+  });
+  mo.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-href'],
+    subtree: true,
+  });
+
+  cleanup = () => mo.disconnect();
+
+  // Fallback on DOMContentLoaded
+  if (document.readyState === 'loading') {
+    const onReady = (): void => {
+      const u = destinationUrl();
+      if (u) finish(u);
+    };
+    document.addEventListener('DOMContentLoaded', onReady, true);
+    // Wrap cleanup to also remove this listener
+    const origCleanup = cleanup;
+    cleanup = (): void => {
+      origCleanup?.();
+      document.removeEventListener('DOMContentLoaded', onReady, true);
+    };
+  }
+}

--- a/src/sites/ouo/auto-submit.ts
+++ b/src/sites/ouo/auto-submit.ts
@@ -15,7 +15,6 @@ const NOTE = {
 
 let ui: FullPageOverlay | null = null;
 let done = false;
-let started = false;
 
 const bootOverlayLock = (): void => {
   const active = overlayActiveClass(OVERLAY_ID);
@@ -59,39 +58,123 @@ function turnstileReady(form: HTMLFormElement): boolean {
   return v.length > 20;
 }
 
-function submitWhenReady(form: HTMLFormElement): void {
-  if (done) return;
-  const overlay = mountUi('Waiting for verification…');
-  const tick = (): void => {
-    if (done) return;
-    if (!document.contains(form)) return;
-    if (!turnstileReady(form)) {
-      window.setTimeout(tick, 150);
-      return;
+const requestVisibilitySpoof = (): void => {
+  try { chrome.runtime.sendMessage({ type: 'INJECT_VISIBILITY_SPOOF' }); } catch {}
+};
+
+/** Find a "Get Link" / "Continue" button on the /go/ page and click it */
+function clickGetLinkButton(): HTMLElement | null {
+  // Try common button/link text patterns
+  const textPatterns = ['get link', 'continue', 'proceed', 'click here', 'redirect', 'download'];
+
+  // 1. Look for buttons/anchors by text content (skip disabled)
+  for (const el of document.querySelectorAll<HTMLElement>('a, button, input[type="submit"], input[type="button"]')) {
+    if ((el as HTMLButtonElement).disabled) continue;
+    const text = (el.textContent ?? '').trim().toLowerCase();
+    if (textPatterns.some((p) => text.includes(p))) {
+      el.click();
+      return el;
     }
-    done = true;
-    overlay.setStatus('Continuing…');
-    form.submit();
-  };
-  tick();
+  }
+
+  // 2. Look for elements by common IDs
+  const ids = ['btn-main', 'get-link', 'getlink', 'redirect-link', 'continue', 'go-link', 'submit-btn', 'download-btn'];
+  for (const id of ids) {
+    const el = document.getElementById(id);
+    if (el && !(el as HTMLButtonElement).disabled && 'click' in HTMLElement.prototype) {
+      (el as HTMLElement).click();
+      return el;
+    }
+  }
+
+  // 3. Look for elements with data attributes
+  const sel = [
+    '[data-get-link]', '[data-redirect]', '[data-url]',
+    '.get-link', '.btn-get-link', '.download-link',
+  ].join(',');
+  const el = document.querySelector<HTMLElement>(sel);
+  if (el && !(el as HTMLButtonElement).disabled) {
+    el.click();
+    return el;
+  }
+
+  return null;
 }
 
-function run(): void {
-  if (started) return;
-  const form = captchaForm();
-  if (!form) return;
-  started = true;
-  submitWhenReady(form);
+/**
+ * On /go/ page: find the actual destination via JS redirect, meta refresh,
+ * or by clicking the "Get Link" button.
+ */
+function handleGoPage(): string | null {
+  // 1. window.location.href redirect in inline script
+  for (const script of document.scripts) {
+    const text = script.textContent ?? '';
+    const m = text.match(/window\.location\.href\s*=\s*"([^"]+)"/);
+    if (m?.[1] && (m[1].startsWith('http://') || m[1].startsWith('https://'))) return m[1];
+  }
+
+  // 2. Meta refresh
+  const meta = document.querySelector<HTMLMetaElement>('meta[http-equiv="refresh"]');
+  if (meta) {
+    const m = (meta.getAttribute('content') ?? '').match(/url=\s*([^\s;]+)/i);
+    if (m?.[1] && (m[1].startsWith('http://') || m[1].startsWith('https://'))) return m[1];
+  }
+
+  // 3. Click "Get Link" / "Continue" button
+  const btn = clickGetLinkButton();
+  if (btn) {
+    done = true; // button clicked, let browser follow the resulting redirect
+    return '';
+  }
+
+  return null;
 }
 
 export function initOuoBypass(): void {
   if (!isAllowedHost(OUO_HOSTS)) return;
 
-  whenDomParsed(run);
+  // ── /go/ redirect page ──
+  if (/^\/go\//.test(location.pathname)) {
+    requestVisibilitySpoof(); // keep countdown running
+    const url = handleGoPage();
+    if (url === '' || done) return; // button was clicked, browser handling it
+    if (url) {
+      done = true;
+      location.replace(url);
+      return;
+    }
+    // Keep trying for a bit (page might load dynamically)
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries++;
+      const u = handleGoPage();
+      if (done || u !== null) {
+        window.clearInterval(id);
+        return;
+      }
+      if (tries >= 30) window.clearInterval(id);
+    }, 200);
+    return;
+  }
 
-  const mo = new MutationObserver(() => {
-    run();
-    if (started) mo.disconnect();
+  // ── Standard captcha page ──
+  requestVisibilitySpoof();
+  whenDomParsed(() => {
+    const form = captchaForm();
+    if (!form) return;
+
+    const overlay = mountUi('Waiting for verification…');
+
+    const check = (): void => {
+      if (done || !document.contains(form)) return;
+      if (!turnstileReady(form)) {
+        window.setTimeout(check, 150);
+        return;
+      }
+      done = true;
+      overlay.setStatus('Continuing…');
+      form.submit();
+    };
+    check();
   });
-  mo.observe(document.documentElement, { childList: true, subtree: true });
 }

--- a/src/sites/tech8s/background.ts
+++ b/src/sites/tech8s/background.ts
@@ -1,0 +1,27 @@
+const LINK4M_FULL_RE = /^https:\/\/link4m\.co\/full\/\?/i;
+
+function decodeBase64(s: string): string {
+  try { return atob(s); } catch { return ''; }
+}
+
+/** Intercept link4m.co/full/ navigations and redirect directly to decoded URL */
+export function initTech8sBackground(): void {
+  chrome.webNavigation.onBeforeNavigate.addListener(
+    (details) => {
+      if (details.frameId !== 0) return;
+      if (!LINK4M_FULL_RE.test(details.url)) return;
+
+      try {
+        const u = new URL(details.url);
+        const raw = u.searchParams.get('url')?.trim();
+        if (!raw) return;
+        const decoded = decodeBase64(raw);
+        if (!decoded.startsWith('http://') && !decoded.startsWith('https://')) return;
+
+        // Redirect directly to the decoded destination
+        chrome.tabs.update(details.tabId, { url: decoded });
+      } catch {}
+    },
+    { url: [{ hostEquals: 'link4m.co', pathPrefix: '/full/' }] },
+  );
+}

--- a/src/sites/tech8s/hosts.ts
+++ b/src/sites/tech8s/hosts.ts
@@ -1,1 +1,1 @@
-export const TECH8S_HOSTS = ['tech8s.net', 'game5s.com', 'ez4short.com'] as const;
+export const TECH8S_HOSTS = ['tech8s.net', 'game5s.com', 'ez4short.com', 'link4m.co'] as const;

--- a/src/sites/tech8s/hosts.ts
+++ b/src/sites/tech8s/hosts.ts
@@ -1,0 +1,1 @@
+export const TECH8S_HOSTS = ['tech8s.net', 'game5s.com', 'ez4short.com'] as const;

--- a/src/sites/tech8s/index.ts
+++ b/src/sites/tech8s/index.ts
@@ -3,7 +3,17 @@ import { TECH8S_HOSTS } from './hosts';
 
 const SAFE_PHP_RE = /^\/safe\.php$/i;
 const EZ4_ST_RE = /^\/st$/i;
+const LINK4M_FULL_RE = /^\/full\/?$/i;
 const LOCATION_HREF_RE = /window\.location\.href\s*=\s*"([^"]+)"/;
+
+/** Decode base64 string */
+function decodeBase64(s: string): string {
+  try {
+    return atob(s);
+  } catch {
+    return '';
+  }
+}
 
 /** Extract URL from inline JS redirect: window.location.href = "..." */
 function extractJsRedirectUrl(): string | null {
@@ -21,14 +31,49 @@ function extractJsRedirectUrl(): string | null {
 /** Extract url param from query string (for /st endpoint) */
 function urlFromQueryParam(): string | null {
   try {
-    const target = new URL(location.href).searchParams.get('url')?.trim();
+    const u = new URL(location.href);
+    const target = u.searchParams.get('url')?.trim();
     if (target && (target.startsWith('http://') || target.startsWith('https://'))) return target;
+  } catch {}
+  return null;
+}
+
+/** Decode base64 url param (for link4m.co /full/ endpoint) */
+function decodedUrlFromQueryParam(): string | null {
+  try {
+    const u = new URL(location.href);
+    const raw = u.searchParams.get('url')?.trim();
+    if (!raw) return null;
+    const decoded = decodeBase64(raw);
+    if (decoded.startsWith('http://') || decoded.startsWith('https://')) return decoded;
   } catch {}
   return null;
 }
 
 export function initTech8sSafeRedirect(): void {
   if (!isAllowedHost(TECH8S_HOSTS)) return;
+
+  // ── link4m.co/full/?api=...&url=<base64>&type=... ──
+  if (LINK4M_FULL_RE.test(location.pathname)) {
+    const url = decodedUrlFromQueryParam();
+    if (url) {
+      location.replace(url);
+      return;
+    }
+    // Fallback: poll briefly
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries++;
+      const u = decodedUrlFromQueryParam();
+      if (u) {
+        window.clearInterval(id);
+        location.replace(u);
+      } else if (tries >= 20) {
+        window.clearInterval(id);
+      }
+    }, 150);
+    return;
+  }
 
   // ── ez4short.com/st?api=...&url=... ──
   if (EZ4_ST_RE.test(location.pathname)) {
@@ -37,7 +82,6 @@ export function initTech8sSafeRedirect(): void {
       location.replace(url);
       return;
     }
-    // Fallback: wait briefly for auto-submit to finish, then check again
     let tries = 0;
     const id = window.setInterval(() => {
       tries++;
@@ -55,14 +99,12 @@ export function initTech8sSafeRedirect(): void {
   // ── tech8s.net / game5s.com / ez4short.com /safe.php?link=... ──
   if (!SAFE_PHP_RE.test(location.pathname)) return;
 
-  // Check immediately (scripts already parsed)
   const url = extractJsRedirectUrl();
   if (url) {
     location.replace(url);
     return;
   }
 
-  // Wait for script tag to appear
   let done = false;
   const mo = new MutationObserver(() => {
     if (done) return;
@@ -75,7 +117,6 @@ export function initTech8sSafeRedirect(): void {
   });
   mo.observe(document.documentElement, { childList: true, subtree: true });
 
-  // Timeout: stop observer after 5s to avoid resource leak
   window.setTimeout(() => {
     if (!done) {
       done = true;

--- a/src/sites/tech8s/index.ts
+++ b/src/sites/tech8s/index.ts
@@ -1,0 +1,85 @@
+import { isAllowedHost } from '../../utils/domain-check';
+import { TECH8S_HOSTS } from './hosts';
+
+const SAFE_PHP_RE = /^\/safe\.php$/i;
+const EZ4_ST_RE = /^\/st$/i;
+const LOCATION_HREF_RE = /window\.location\.href\s*=\s*"([^"]+)"/;
+
+/** Extract URL from inline JS redirect: window.location.href = "..." */
+function extractJsRedirectUrl(): string | null {
+  for (const script of document.scripts) {
+    const text = script.textContent ?? '';
+    if (!text.includes('window.location.href')) continue;
+    const m = LOCATION_HREF_RE.exec(text);
+    if (!m?.[1]) continue;
+    const url = m[1].trim();
+    if (url.startsWith('http://') || url.startsWith('https://')) return url;
+  }
+  return null;
+}
+
+/** Extract url param from query string (for /st endpoint) */
+function urlFromQueryParam(): string | null {
+  try {
+    const target = new URL(location.href).searchParams.get('url')?.trim();
+    if (target && (target.startsWith('http://') || target.startsWith('https://'))) return target;
+  } catch {}
+  return null;
+}
+
+export function initTech8sSafeRedirect(): void {
+  if (!isAllowedHost(TECH8S_HOSTS)) return;
+
+  // ── ez4short.com/st?api=...&url=... ──
+  if (EZ4_ST_RE.test(location.pathname)) {
+    const url = urlFromQueryParam();
+    if (url) {
+      location.replace(url);
+      return;
+    }
+    // Fallback: wait briefly for auto-submit to finish, then check again
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries++;
+      const u = urlFromQueryParam();
+      if (u) {
+        window.clearInterval(id);
+        location.replace(u);
+      } else if (tries >= 20) {
+        window.clearInterval(id);
+      }
+    }, 150);
+    return;
+  }
+
+  // ── tech8s.net / game5s.com / ez4short.com /safe.php?link=... ──
+  if (!SAFE_PHP_RE.test(location.pathname)) return;
+
+  // Check immediately (scripts already parsed)
+  const url = extractJsRedirectUrl();
+  if (url) {
+    location.replace(url);
+    return;
+  }
+
+  // Wait for script tag to appear
+  let done = false;
+  const mo = new MutationObserver(() => {
+    if (done) return;
+    const u = extractJsRedirectUrl();
+    if (u) {
+      done = true;
+      mo.disconnect();
+      location.replace(u);
+    }
+  });
+  mo.observe(document.documentElement, { childList: true, subtree: true });
+
+  // Timeout: stop observer after 5s to avoid resource leak
+  window.setTimeout(() => {
+    if (!done) {
+      done = true;
+      mo.disconnect();
+    }
+  }, 5000);
+}


### PR DESCRIPTION
## Changes

### New sites supported:
- **1shortlink.com** — bypass `/link-encrypted/` page by waiting for AJAX `getLink` to return destination URL stored in `#redirect-link data-href`
- **tech8s.net / game5s.com / ez4short.com** — bypass `/safe.php` JS redirect gateway by extracting URL from `window.location.href = "..."` inline script

### Improvements:
- **ouo.io / ouo.press** — added `btn-main` ID to button detection list; improved `/go/` page handling with text-based button matching (`Get Link`, `Continue`, `Lấy mã`); added visibility spoof request

### Files:
| File | Status |
|------|--------|
| `src/sites/1shortlink/hosts.ts` | new |
| `src/sites/1shortlink/index.ts` | new |
| `src/sites/tech8s/hosts.ts` | new |
| `src/sites/tech8s/index.ts` | new |
| `src/sites/ouo/auto-submit.ts` | modified |
| `src/content-scripts/index.ts` | modified |